### PR TITLE
use global to get CFG variable

### DIFF
--- a/local/elisprogram/lib/data/userset.class.php
+++ b/local/elisprogram/lib/data/userset.class.php
@@ -25,7 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once(dirname(__FILE__).'/../../../../config.php');
+global $CFG;
+
 require_once($CFG->dirroot.'/local/elisprogram/lib/setup.php');
 require_once(elis::lib('data/data_object_with_custom_fields.class.php'));
 require_once(elispm::lib('contexts.php'));


### PR DESCRIPTION
Hi, 

I have this problem when moodle try to load the config.php file, in this point moodle has booted and only needed use the global key to user the CFG variable.

```
Notice: Undefined variable: CFG /var/www/htdocs/local/elisprogram/lib/data/userset.class.php on line 29
Call Stack
#   Time    Memory  Function    Location
1   0.0022  268792  {main}( )   .../index.php:0
2   0.0535  4892432 elis_page->run( )   .../index.php:232
3   0.0828  5695792 elis_page->display( )   .../page.class.php:347
4   0.2632  11388816    call_user_func:{/var/www/htdocs/local/eliscore/lib/page.class.php:391} ( )  .../page.class.php:391
5   0.2632  11389080    local_elisprogram\pages\healthcheck->display_default( ) .../page.class.php:391
6   0.2654  11455984    local_elisprogram\lib\health\clusterorphans->__construct( ) .../healthcheck.php:134
7   0.2655  11483592    require_once( '/var/www/htdocs/local/elisprogram/lib/data/userset.class.php' )  .../clusterorphans.php:42
```
